### PR TITLE
tink-signature: bump p256 dep from 0.7.2 to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca0196a204bb3f33305ba4a48b38f6e6e621cba8603a4e0650e6532e0949de4"
+checksum = "8adcc06fe90ec8fb2d2ad46746d2cbd639b158d4240364aa832da7e263dbee91"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography"]
 [dependencies]
 ed25519-dalek = "^1.0.1"
 generic-array = "^0.14"
-p256 = { version = "^0.7", features = ["ecdsa"] }
+p256 = "^0.7.3"
 prost = "^0.7"
 rand = "^0.7"
 signature = "^1.2.2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography"]
 ed25519-dalek = "^1.0.1"
 generic-array = "^0.14.4"
 hex = "^0.4.3"
-p256 = { version = "^0.7", features = ["ecdsa"] }
+p256 = "^0.7.3"
 prost = "^0.7"
 rand = "^0.7"
 serde = { version = "^1.0.125", features = ["derive"] }


### PR DESCRIPTION
With 0.7.3 the `ecdsa` feature is included by default, so no
longer needs to be specified locally.