### PR TITLE
Update zeroize_derive dep to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deny.toml
+++ b/deny.toml
@@ -15,10 +15,7 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#202): Remove when zeroize_derive upgraded
-  "RUSTSEC-2021-0115",
-]
+ignore = []
 
 # Deny multiple versions unless explicitly skipped.
 [bans]


### PR DESCRIPTION
Fixes #202. No need for RUSTSEC-2021-0115 exception now.