### PR TITLE
Simplify error expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/core/src/subtle/hkdf.rs
+++ b/core/src/subtle/hkdf.rs
@@ -27,7 +27,7 @@ fn validate_hkdf_params(
     hash: HashType,
     _key_size: usize,
     tag_size: usize,
-) -> Result<(), crate::TinkError> {
+) -> Result<(), TinkError> {
     // validate tag size
     let digest_size = super::get_hash_digest_size(hash)?;
     if tag_size > 255 * digest_size {
@@ -46,7 +46,7 @@ pub fn compute_hkdf(
     salt: &[u8],
     info: &[u8],
     tag_size: usize,
-) -> Result<Vec<u8>, crate::TinkError> {
+) -> Result<Vec<u8>, TinkError> {
     let key_size = key.len();
     validate_hkdf_params(hash_alg, key_size, tag_size).map_err(|e| wrap_err("hkdf", e))?;
 
@@ -65,14 +65,14 @@ fn compute_hkdf_with<D>(
     salt: &[u8],
     info: &[u8],
     tag_size: usize,
-) -> Result<Vec<u8>, crate::TinkError>
+) -> Result<Vec<u8>, TinkError>
 where
     D: digest::Update + digest::BlockInput + digest::FixedOutput + digest::Reset + Default + Clone,
 {
     let prk = hkdf::Hkdf::<D>::new(Some(salt), key);
     let mut okm = vec![0; tag_size];
     prk.expand(info, &mut okm)
-        .map_err(|_| TinkError::new("compute of hkdf failed"))?;
+        .map_err(|_| "compute of hkdf failed")?;
 
     Ok(okm)
 }

--- a/daead/src/aes_siv_key_manager.rs
+++ b/daead/src/aes_siv_key_manager.rs
@@ -56,7 +56,7 @@ impl KeyManager for AesSivKeyManager {
         if !serialized_key_format.is_empty() {
             // If a key format was provided, check it is valid.
             let key_format = tink_proto::AesSivKeyFormat::decode(serialized_key_format)
-                .map_err(|_| TinkError::new("AesSivKeyManager: invalid key format"))?;
+                .map_err(|_| "AesSivKeyManager: invalid key format")?;
             if key_format.key_size as usize != subtle::AES_SIV_KEY_SIZE {
                 return Err(format!(
                     "AesSivKeyManager: key_format.key_size != {}",

--- a/mac/src/aes_cmac_key_manager.rs
+++ b/mac/src/aes_cmac_key_manager.rs
@@ -55,7 +55,7 @@ impl tink_core::registry::KeyManager for AesCmacKeyManager {
             return Err("AesCmacKeyManager: invalid key format".into());
         }
         let key_format = tink_proto::AesCmacKeyFormat::decode(serialized_key_format)
-            .map_err(|_| TinkError::new("AesCmacKeyManager: invalid key format"))?;
+            .map_err(|_| "AesCmacKeyManager: invalid key format")?;
         validate_key_format(&key_format)
             .map_err(|e| wrap_err("AesCmacKeyManager: invalid key format", e))?;
         let key_value = tink_core::subtle::random::get_random_bytes(key_format.key_size as usize);

--- a/mac/src/hmac_key_manager.rs
+++ b/mac/src/hmac_key_manager.rs
@@ -57,7 +57,7 @@ impl tink_core::registry::KeyManager for HmacKeyManager {
             return Err("HmacKeyManager: invalid key format".into());
         }
         let key_format = tink_proto::HmacKeyFormat::decode(serialized_key_format)
-            .map_err(|_| TinkError::new("HmacKeyManager: invalid key format"))?;
+            .map_err(|_| "HmacKeyManager: invalid key format")?;
         validate_key_format(&key_format)
             .map_err(|e| wrap_err("HmacKeyManager: invalid key format", e))?;
         let key_value = tink_core::subtle::random::get_random_bytes(key_format.key_size as usize);

--- a/prf/src/aes_cmac_prf_key_manager.rs
+++ b/prf/src/aes_cmac_prf_key_manager.rs
@@ -38,7 +38,7 @@ impl tink_core::registry::KeyManager for AesCmacPrfKeyManager {
         }
 
         let key = tink_proto::AesCmacPrfKey::decode(serialized_key)
-            .map_err(|_| TinkError::new("AesCmacPrfKeyManager: invalid key"))?;
+            .map_err(|_| "AesCmacPrfKeyManager: invalid key")?;
         validate_key(&key)?;
         match subtle::AesCmacPrf::new(&key.key_value) {
             Ok(p) => Ok(tink_core::Primitive::Prf(Box::new(p))),
@@ -56,7 +56,7 @@ impl tink_core::registry::KeyManager for AesCmacPrfKeyManager {
             return Err("AesCmacPrfKeyManager: invalid key format".into());
         }
         let key_format = tink_proto::AesCmacPrfKeyFormat::decode(serialized_key_format)
-            .map_err(|_| TinkError::new("AesCmacPrfKeyManager: invalid key format"))?;
+            .map_err(|_| "AesCmacPrfKeyManager: invalid key format")?;
         validate_key_format(&key_format)
             .map_err(|e| wrap_err("AesCmacPrfKeyManager: invalid key format", e))?;
         let key_value = tink_core::subtle::random::get_random_bytes(key_format.key_size as usize);

--- a/prf/src/hkdf_prf_key_manager.rs
+++ b/prf/src/hkdf_prf_key_manager.rs
@@ -36,7 +36,7 @@ impl tink_core::registry::KeyManager for HkdfPrfKeyManager {
             return Err("HkdfPrfKeyManager: invalid key".into());
         }
         let key = tink_proto::HkdfPrfKey::decode(serialized_key)
-            .map_err(|_| TinkError::new("HkdfPrfKeyManager: invalid key"))?;
+            .map_err(|_| "HkdfPrfKeyManager: invalid key")?;
         let (params, hash) = validate_key(&key).map_err(|e| wrap_err("HkdfPrfKeyManager", e))?;
 
         match subtle::HkdfPrf::new(hash, &key.key_value, &params.salt) {
@@ -53,7 +53,7 @@ impl tink_core::registry::KeyManager for HkdfPrfKeyManager {
         }
 
         let key_format = tink_proto::HkdfPrfKeyFormat::decode(serialized_key_format)
-            .map_err(|_| TinkError::new("HkdfPrfKeyManager: invalid key format"))?;
+            .map_err(|_| "HkdfPrfKeyManager: invalid key format")?;
         validate_key_format(&key_format)
             .map_err(|e| wrap_err("HkdfPrfKeyManager: invalid key format", e))?;
 

--- a/prf/src/hmac_prf_key_manager.rs
+++ b/prf/src/hmac_prf_key_manager.rs
@@ -36,7 +36,7 @@ impl tink_core::registry::KeyManager for HmacPrfKeyManager {
             return Err("HmacPrfKeyManager: invalid key".into());
         }
         let key = tink_proto::HmacPrfKey::decode(serialized_key)
-            .map_err(|_| TinkError::new("HmacPrfKeyManager: invalid key"))?;
+            .map_err(|_| "HmacPrfKeyManager: invalid key")?;
         let (_params, hash) = validate_key(&key).map_err(|e| wrap_err("HmacPrfKeyManager", e))?;
 
         match subtle::HmacPrf::new(hash, &key.key_value) {
@@ -52,7 +52,7 @@ impl tink_core::registry::KeyManager for HmacPrfKeyManager {
             return Err("HmacPrfKeyManager: invalid key format".into());
         }
         let key_format = tink_proto::HmacPrfKeyFormat::decode(serialized_key_format)
-            .map_err(|_| TinkError::new("HmacPrfKeyManager: invalid key format"))?;
+            .map_err(|_| "HmacPrfKeyManager: invalid key format")?;
         validate_key_format(&key_format)
             .map_err(|e| wrap_err("HmacPrfKeyManager: invalid key format", e))?;
 

--- a/prf/src/subtle/aes_cmac.rs
+++ b/prf/src/subtle/aes_cmac.rs
@@ -45,16 +45,13 @@ impl AesCmacPrf {
     pub fn new(key: &[u8]) -> Result<AesCmacPrf, TinkError> {
         let aes_cmac = match key.len() {
             16 => AesCmacVariant::Aes128(Box::new(
-                Cmac::<Aes128>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("failed to create key"))?,
+                Cmac::<Aes128>::new_from_slice(key).map_err(|_| "failed to create key")?,
             )),
             24 => AesCmacVariant::Aes192(Box::new(
-                Cmac::<Aes192>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("failed to create key"))?,
+                Cmac::<Aes192>::new_from_slice(key).map_err(|_| "failed to create key")?,
             )),
             32 => AesCmacVariant::Aes256(Box::new(
-                Cmac::<Aes256>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("failed to create key"))?,
+                Cmac::<Aes256>::new_from_slice(key).map_err(|_| "failed to create key")?,
             )),
             _ => return Err("AesCmacPrf: invalid key length for AES".into()),
         };

--- a/prf/src/subtle/hkdf.rs
+++ b/prf/src/subtle/hkdf.rs
@@ -94,7 +94,7 @@ where
 {
     let mut okm = vec![0; out_len];
     prk.expand(data, &mut okm)
-        .map_err(|_| TinkError::new("HkdfPrf: compute of hkdf failed"))?;
+        .map_err(|_| "HkdfPrf: compute of hkdf failed")?;
 
     Ok(okm)
 }

--- a/prf/src/subtle/hmac.rs
+++ b/prf/src/subtle/hmac.rs
@@ -47,24 +47,23 @@ impl HmacPrf {
     pub fn new(hash_alg: HashType, key: &[u8]) -> Result<HmacPrf, TinkError> {
         let mac = match hash_alg {
             HashType::Sha1 => HmacPrfVariant::Sha1(
-                Hmac::<sha1::Sha1>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("HmacPrf: invalid key size"))?,
+                Hmac::<sha1::Sha1>::new_from_slice(key).map_err(|_| "HmacPrf: invalid key size")?,
             ),
             HashType::Sha224 => HmacPrfVariant::Sha224(
                 Hmac::<sha2::Sha224>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("HmacPrf: invalid key size"))?,
+                    .map_err(|_| "HmacPrf: invalid key size")?,
             ),
             HashType::Sha256 => HmacPrfVariant::Sha256(
                 Hmac::<sha2::Sha256>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("HmacPrf: invalid key size"))?,
+                    .map_err(|_| "HmacPrf: invalid key size")?,
             ),
             HashType::Sha384 => HmacPrfVariant::Sha384(
                 Hmac::<sha2::Sha384>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("HmacPrf: invalid key size"))?,
+                    .map_err(|_| "HmacPrf: invalid key size")?,
             ),
             HashType::Sha512 => HmacPrfVariant::Sha512(
                 Hmac::<sha2::Sha512>::new_from_slice(key)
-                    .map_err(|_| TinkError::new("HmacPrf: invalid key size"))?,
+                    .map_err(|_| "HmacPrf: invalid key size")?,
             ),
             h => return Err(format!("HmacPrf: unsupported hash {:?}", h).into()),
         };

--- a/tests/tests/hybrid/subtle/elliptic_curves_test.rs
+++ b/tests/tests/hybrid/subtle/elliptic_curves_test.rs
@@ -751,7 +751,7 @@ fn convert_x509_public_key(
     match curve {
         EllipticCurveType::NistP256 => {
             let pub_key = p256::PublicKey::from_public_key_der(b)
-                .map_err(|_e| TinkError::new("failed to decode X509 public key"))?;
+                .map_err(|_e| "failed to decode X509 public key")?;
             Ok(subtle::EcPublicKey::NistP256(*pub_key.as_affine()))
         }
         _ => Err(format!("unsupported curve {:?}", curve).into()),

--- a/tests/tests/prf/prf_key_templates_test.rs
+++ b/tests/tests/prf/prf_key_templates_test.rs
@@ -87,7 +87,7 @@ fn check_hmac_template(
         return Err("Not RAW output prefix".into());
     }
     let format = tink_proto::HmacPrfKeyFormat::decode(template.value.as_ref())
-        .map_err(|_| TinkError::new("unable to unmarshal serialized key format"))?;
+        .map_err(|_| "unable to unmarshal serialized key format")?;
     if format.key_size != key_size || format.params.unwrap().hash != hash_type as i32 {
         return Err("KeyFormat is incorrect".into());
     }
@@ -114,7 +114,7 @@ fn check_hkdf_template(
     }
 
     let format = tink_proto::HkdfPrfKeyFormat::decode(template.value.as_ref())
-        .map_err(|_| TinkError::new("unable to unmarshal serialized key format"))?;
+        .map_err(|_| "unable to unmarshal serialized key format")?;
     if format.key_size != key_size
         || format.params.as_ref().unwrap().hash != hash_type as i32
         || hex::encode(salt) != hex::encode(format.params.unwrap().salt)
@@ -139,7 +139,7 @@ fn check_cmac_template(template: &tink_proto::KeyTemplate, key_size: u32) -> Res
     }
 
     let format = tink_proto::AesCmacPrfKeyFormat::decode(template.value.as_ref())
-        .map_err(|_| TinkError::new("unable to unmarshal serialized key format"))?;
+        .map_err(|_| "unable to unmarshal serialized key format")?;
     if format.key_size != key_size {
         return Err("KeyFormat is incorrect".into());
     }


### PR DESCRIPTION
`TinkError` implements `From<String>`, and Rust will use this in
expressions that use the question mark operator, so explicit constructor
calls can be elided.