### PR TITLE
tink-aead: check for AAD size overflow

### DIFF
--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.4 - TBD
 
+- Fix potential AAD overflow vulnerability on 32-bit platforms.
 - Increase MSRV to 1.52.0
 - Upgrade dependencies
 

--- a/aead/README.md
+++ b/aead/README.md
@@ -32,6 +32,15 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+## Known Issues
+
+- Before version 0.2.4, AES-CTR-HMAC-AEAD keys and the
+  [`subtle::EncryptThenAuthenticate`](https://docs.rs/tink-aead/latest/tink_aead/subtle/struct.EncryptThenAuthenticate.html)
+  implementation may be vulnerable to chosen-ciphertext attacks. An attacker can generate ciphertexts that bypass the
+  HMAC verification if and only if all of the following conditions are true:
+    - Tink is used on systems where `usize` is a 32-bit integer. This is usually the case on 32-bit machines.
+    - The attacker can specify long (>= 2^29 bytes ~ 536MB) associated data
+
 ## Disclaimer
 
 This is not an officially supported Google product.

--- a/aead/src/subtle/encrypt_then_authenticate.rs
+++ b/aead/src/subtle/encrypt_then_authenticate.rs
@@ -81,11 +81,9 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + ciphertext.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(&ciphertext);
-        let aad_size_in_bits = (additional_data.len() as u64) * 8;
-        if (aad_size_in_bits / 8) != (additional_data.len() as u64) {
-            // Overflow occurred!
-            return Err("EncryptThenAuthenticate: additional data too long".into());
-        }
+        let aad_size_in_bits = (additional_data.len() as u64)
+            .checked_mul(8)
+            .ok_or_else(|| TinkError::new("EncryptThenAuthenticate: additional data too long"))?;
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());
 
         let tag = self
@@ -116,11 +114,9 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + payload.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(payload);
-        let aad_size_in_bits = (additional_data.len() as u64) * 8;
-        if (aad_size_in_bits / 8) != (additional_data.len() as u64) {
-            // Overflow occurred!
-            return Err("EncryptThenAuthenticate: additional data too long".into());
-        }
+        let aad_size_in_bits = (additional_data.len() as u64)
+            .checked_mul(8)
+            .ok_or_else(|| TinkError::new("EncryptThenAuthenticate: additional data too long"))?;
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());
 
         // Verify against the tag at the end of the ciphertext.

--- a/aead/src/subtle/encrypt_then_authenticate.rs
+++ b/aead/src/subtle/encrypt_then_authenticate.rs
@@ -81,7 +81,7 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + ciphertext.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(&ciphertext);
-        let aad_size_in_bits = (additional_data.len() as u64)
+        let aad_size_in_bits: u64 = (additional_data.len() as u64)
             .checked_mul(8)
             .ok_or_else(|| TinkError::new("EncryptThenAuthenticate: additional data too long"))?;
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());
@@ -114,7 +114,7 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + payload.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(payload);
-        let aad_size_in_bits = (additional_data.len() as u64)
+        let aad_size_in_bits: u64 = (additional_data.len() as u64)
             .checked_mul(8)
             .ok_or_else(|| TinkError::new("EncryptThenAuthenticate: additional data too long"))?;
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());

--- a/aead/src/subtle/encrypt_then_authenticate.rs
+++ b/aead/src/subtle/encrypt_then_authenticate.rs
@@ -81,7 +81,11 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + ciphertext.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(&ciphertext);
-        let aad_size_in_bits = (additional_data.len() * 8) as u64;
+        let aad_size_in_bits = (additional_data.len() as u64) * 8;
+        if (aad_size_in_bits / 8) != (additional_data.len() as u64) {
+            // Overflow occurred!
+            return Err("EncryptThenAuthenticate: additional data too long".into());
+        }
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());
 
         let tag = self
@@ -112,7 +116,11 @@ impl tink_core::Aead for EncryptThenAuthenticate {
         let mut to_auth_data = Vec::with_capacity(additional_data.len() + payload.len() + 8);
         to_auth_data.extend_from_slice(additional_data);
         to_auth_data.extend_from_slice(payload);
-        let aad_size_in_bits = (additional_data.len() * 8) as u64;
+        let aad_size_in_bits = (additional_data.len() as u64) * 8;
+        if (aad_size_in_bits / 8) != (additional_data.len() as u64) {
+            // Overflow occurred!
+            return Err("EncryptThenAuthenticate: additional data too long".into());
+        }
         to_auth_data.extend_from_slice(&aad_size_in_bits.to_be_bytes());
 
         // Verify against the tag at the end of the ciphertext.


### PR DESCRIPTION
The Rust code for `EncryptThenAuthenticate` accidentally re-introduced a
problem first seen in the upstream C++ code before 1.4.0, where an AAD
longer than 2^29 ends up with a size-in-bits that overflows a `usize`
when running on a 32-bit platform.

Fixes #293