### PR TITLE
Move to inline format arguments

### DIFF
--- a/aead/src/subtle/aead.rs
+++ b/aead/src/subtle/aead.rs
@@ -20,6 +20,6 @@
 pub fn validate_aes_key_size(size_in_bytes: usize) -> Result<(), tink_core::TinkError> {
     match size_in_bytes {
         16 | 32 => Ok(()),
-        _ => Err(format!("invalid AES key size; want 16 or 32, got {}", size_in_bytes).into()),
+        _ => Err(format!("invalid AES key size; want 16 or 32, got {size_in_bytes}").into()),
     }
 }

--- a/aead/src/subtle/aes_ctr.rs
+++ b/aead/src/subtle/aes_ctr.rs
@@ -50,7 +50,7 @@ impl AesCtr {
         let key_size = key.len();
         super::validate_aes_key_size(key_size).map_err(|e| wrap_err("AesCtr", e))?;
         if !(AES_CTR_MIN_IV_SIZE..=AES_BLOCK_SIZE_IN_BYTES).contains(&iv_size) {
-            return Err(format!("AesCtr: invalid IV size: {}", iv_size).into());
+            return Err(format!("AesCtr: invalid IV size: {iv_size}").into());
         }
         let key = match key.len() {
             16 => {
@@ -59,7 +59,7 @@ impl AesCtr {
             32 => {
                 AesCtrVariant::Aes256(key.to_vec().try_into().unwrap(/* safe: len checked */))
             }
-            l => return Err(format!("AesCtr: invalid AES key size {} (want 16, 32)", l).into()),
+            l => return Err(format!("AesCtr: invalid AES key size {l} (want 16, 32)").into()),
         };
         Ok(AesCtr { key, iv_size })
     }

--- a/aead/src/subtle/aes_gcm.rs
+++ b/aead/src/subtle/aes_gcm.rs
@@ -53,7 +53,7 @@ impl AesGcm {
             32 => AesGcmVariant::Aes256(Box::new(aes_gcm::Aes256Gcm::new(
                 GenericArray::from_slice(key),
             ))),
-            l => return Err(format!("AesGcm: invalid AES key size {} (want 16, 32)", l).into()),
+            l => return Err(format!("AesGcm: invalid AES key size {l} (want 16, 32)").into()),
         };
         Ok(AesGcm { key })
     }

--- a/aead/src/subtle/aes_gcm_siv.rs
+++ b/aead/src/subtle/aes_gcm_siv.rs
@@ -51,7 +51,7 @@ impl AesGcmSiv {
             32 => AesGcmSivVariant::Aes256(Box::new(aes_gcm_siv::Aes256GcmSiv::new(
                 GenericArray::from_slice(key),
             ))),
-            l => return Err(format!("AesGcmSiv: invalid AES key size {} (want 16, 32)", l).into()),
+            l => return Err(format!("AesGcmSiv: invalid AES key size {l} (want 16, 32)").into()),
         };
         Ok(AesGcmSiv { key })
     }

--- a/core/src/keyset/manager.rs
+++ b/core/src/keyset/manager.rs
@@ -103,7 +103,7 @@ impl Manager {
                 };
             }
         }
-        Err(format!("Key {} not found", key_id).into())
+        Err(format!("Key {key_id} not found").into())
     }
 
     /// Sets the status of the specified key to [`KeyStatusType::Disabled`].
@@ -111,7 +111,7 @@ impl Manager {
     /// is not primary and has status [`KeyStatusType::Disabled`] or [`KeyStatusType::Enabled`].
     pub fn disable(&mut self, key_id: KeyId) -> Result<(), TinkError> {
         if self.ks.primary_key_id == key_id {
-            return Err(format!("Cannot disable primary key (key_id {})", key_id).into());
+            return Err(format!("Cannot disable primary key (key_id {key_id})").into());
         }
         for key in &mut self.ks.key {
             if key.key_id == key_id {
@@ -128,7 +128,7 @@ impl Manager {
                 };
             }
         }
-        Err(format!("Key {} not found", key_id).into())
+        Err(format!("Key {key_id} not found").into())
     }
 
     /// Sets the status of the specified key to [`KeyStatusType::Destroyed`], and removes the
@@ -137,7 +137,7 @@ impl Manager {
     /// [`KeyStatusType::Enabled`], or [`KeyStatusType::Destroyed`].
     pub fn destroy(&mut self, key_id: KeyId) -> Result<(), TinkError> {
         if self.ks.primary_key_id == key_id {
-            return Err(format!("Cannot destroy primary key (key_id {})", key_id).into());
+            return Err(format!("Cannot destroy primary key (key_id {key_id})").into());
         }
         for key in &mut self.ks.key {
             if key.key_id == key_id {
@@ -157,14 +157,14 @@ impl Manager {
                 };
             }
         }
-        Err(format!("Key {} not found", key_id).into())
+        Err(format!("Key {key_id} not found").into())
     }
 
     /// Removes the specifed key from the managed keyset.  Succeeds only if the specified key is not
     /// primary.  After deletion the keyset contains one key fewer.
     pub fn delete(&mut self, key_id: KeyId) -> Result<(), TinkError> {
         if self.ks.primary_key_id == key_id {
-            return Err(format!("Cannot delete primary key (key_id {})", key_id).into());
+            return Err(format!("Cannot delete primary key (key_id {key_id})").into());
         }
         let mut idx: Option<usize> = None;
         for (i, key) in self.ks.key.iter().enumerate() {
@@ -178,7 +178,7 @@ impl Manager {
                 self.ks.key.remove(i);
                 Ok(())
             }
-            None => Err(format!("Key {} not found", key_id).into()),
+            None => Err(format!("Key {key_id} not found").into()),
         }
     }
 
@@ -199,7 +199,7 @@ impl Manager {
                 };
             }
         }
-        Err(format!("Key {} not found", key_id).into())
+        Err(format!("Key {key_id} not found").into())
     }
 
     /// Return the count of all keys in the keyset.

--- a/core/src/keyset/validation.rs
+++ b/core/src/keyset/validation.rs
@@ -23,8 +23,7 @@ use crate::TinkError;
 pub fn validate_key_version(version: u32, max_expected: u32) -> Result<(), TinkError> {
     if version > max_expected {
         Err(format!(
-            "key has version {}; only keys with version in range [0..{}] are supported",
-            version, max_expected
+            "key has version {version}; only keys with version in range [0..{max_expected}] are supported",
         )
         .into())
     } else {

--- a/core/src/registry/mod.rs
+++ b/core/src/registry/mod.rs
@@ -62,11 +62,9 @@ where
 
     let type_url = km.type_url();
     if key_mgrs.contains_key(type_url) {
-        return Err(format!(
-            "registry::register_key_manager: type {} already registered",
-            type_url
-        )
-        .into());
+        return Err(
+            format!("registry::register_key_manager: type {type_url} already registered",).into(),
+        );
     }
     key_mgrs.insert(type_url, km);
     Ok(())
@@ -77,8 +75,7 @@ pub fn get_key_manager(type_url: &str) -> Result<Arc<dyn KeyManager>, TinkError>
     let key_mgrs = KEY_MANAGERS.read().expect(MERR); // safe: lock
     let km = key_mgrs.get(type_url).ok_or_else(|| {
         TinkError::new(&format!(
-            "registry::get_key_manager: unsupported key type: {}",
-            type_url
+            "registry::get_key_manager: unsupported key type: {type_url}",
         ))
     })?;
     Ok(km.clone())
@@ -131,5 +128,5 @@ pub fn get_kms_client(key_uri: &str) -> Result<Arc<dyn KmsClient>, TinkError> {
             return Ok(k.clone());
         }
     }
-    Err(format!("KMS client supporting {} not found", key_uri).into())
+    Err(format!("KMS client supporting {key_uri} not found").into())
 }

--- a/core/src/subtle/hkdf.rs
+++ b/core/src/subtle/hkdf.rs
@@ -72,7 +72,7 @@ pub fn compute_hkdf(
             prk.expand(info, &mut okm)
                 .map_err(|_| "compute of hkdf failed")?;
         }
-        h => return Err(format!("hkdf: unsupported hash {:?}", h).into()),
+        h => return Err(format!("hkdf: unsupported hash {h:?}").into()),
     }
     Ok(okm)
 }

--- a/docs/RUST-HOWTO.md
+++ b/docs/RUST-HOWTO.md
@@ -242,7 +242,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // is initialized.
     let kh = tink_core::keyset::Handle::new(&tink_daead::aes_siv_key_template())?;
 
-    println!("{:?}", kh);
+    println!("{kh:?}");
     Ok(())
 }
 ```
@@ -281,7 +281,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new keyset handle for the current state of the managed keyset.
     let kh2 = km.handle()?;
-    println!("{:?}", kh2); // debug output does not include key material
+    println!("{kh2:?}"); // debug output does not include key material
 
     // The original key is still in the keyset, and so can decrypt.
     let cipher2 = tink_aead::new(&kh2)?;
@@ -292,7 +292,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     km.set_primary(key_id_b)?;
     km.disable(key_id_a)?;
     let kh3 = km.handle()?;
-    println!("{:?}", kh3);
+    println!("{kh3:?}");
     Ok(())
 }
 ```

--- a/examples/keygen/src/main.rs
+++ b/examples/keygen/src/main.rs
@@ -25,6 +25,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     // is initialized.
     let kh = tink_core::keyset::Handle::new(&tink_daead::aes_siv_key_template())?;
 
-    println!("{:?}", kh);
+    println!("{kh:?}");
     Ok(())
 }

--- a/examples/keymgr/src/main.rs
+++ b/examples/keymgr/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new keyset handle for the current state of the managed keyset.
     let kh2 = km.handle()?;
-    println!("{:?}", kh2); // debug output does not include key material
+    println!("{kh2:?}"); // debug output does not include key material
 
     // The original key is still in the keyset, and so can decrypt.
     let cipher2 = tink_aead::new(&kh2)?;
@@ -49,6 +49,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     km.set_primary(key_id_b)?;
     km.disable(key_id_a)?;
     let kh3 = km.handle()?;
-    println!("{:?}", kh3);
+    println!("{kh3:?}");
     Ok(())
 }

--- a/hybrid/src/ecies_aead_hkdf_dem_helper.rs
+++ b/hybrid/src/ecies_aead_hkdf_dem_helper.rs
@@ -112,7 +112,7 @@ impl subtle::EciesAeadHkdfDemHelper for EciesAeadHkdfDemHelper {
         &self,
         symmetric_key_value: &[u8],
     ) -> Result<tink_core::Primitive, tink_core::TinkError> {
-        if symmetric_key_value.len() != self.get_symmetric_key_size() as usize {
+        if symmetric_key_value.len() != self.get_symmetric_key_size() {
             return Err("symmetric key has incorrect length".into());
         }
         let mut sk = Vec::new();

--- a/hybrid/src/subtle/elliptic_curves.rs
+++ b/hybrid/src/subtle/elliptic_curves.rs
@@ -55,7 +55,7 @@ impl EcPublicKey {
                 .ok_or_else(|| TinkError::new("invalid point"))?;
                 Ok(EcPublicKey::NistP256(affine_pt))
             }
-            _ => Err(format!("unsupported curve {:?}", curve).into()),
+            _ => Err(format!("unsupported curve {curve:?}").into()),
         }
     }
 
@@ -124,7 +124,7 @@ impl EcPrivateKey {
                     .ok_or_else(|| TinkError::new("failed to parse D value"))?;
                 Ok(EcPrivateKey::NistP256(d_scalar))
             }
-            _ => Err(format!("unsupported curve {:?}", curve).into()),
+            _ => Err(format!("unsupported curve {curve:?}").into()),
         }
     }
 }
@@ -132,7 +132,7 @@ impl EcPrivateKey {
 fn field_size_in_bytes(c: EllipticCurveType) -> Result<usize, TinkError> {
     match c {
         EllipticCurveType::NistP256 => Ok(elliptic_curve::FieldSize::<p256::NistP256>::to_usize()),
-        _ => Err(format!("unsupported curve {:?}", c).into()),
+        _ => Err(format!("unsupported curve {c:?}").into()),
     }
 }
 
@@ -142,7 +142,7 @@ pub fn encoding_size_in_bytes(c: EllipticCurveType, p: EcPointFormat) -> Result<
         EcPointFormat::Uncompressed => Ok(2 * c_size + 1), // 04 || x || y
         EcPointFormat::DoNotUseCrunchyUncompressed => Ok(2 * c_size), // x || y
         EcPointFormat::Compressed => Ok(c_size + 1),       // {02,03} || x
-        _ => Err(format!("invalid point format {:?}", p).into()),
+        _ => Err(format!("invalid point format {p:?}").into()),
     }
 }
 
@@ -203,7 +203,7 @@ pub fn point_decode(
                         .map_err(|e| wrap_err("invalid point", e))?;
                     Ok(EcPublicKey::NistP256(*pub_key.as_affine()))
                 }
-                _ => Err(format!("unsupported curve {:?}", c).into()),
+                _ => Err(format!("unsupported curve {c:?}").into()),
             }
         }
         EcPointFormat::DoNotUseCrunchyUncompressed => {
@@ -230,10 +230,10 @@ pub fn point_decode(
                         .map_err(|e| wrap_err("invalid point", e))?;
                     Ok(EcPublicKey::NistP256(*pub_key.as_affine()))
                 }
-                _ => Err(format!("unsupported curve {:?}", c).into()),
+                _ => Err(format!("unsupported curve {c:?}").into()),
             }
         }
-        _ => Err(format!("invalid point format: {:?}", p_format).into()),
+        _ => Err(format!("invalid point format: {p_format:?}").into()),
     }
 }
 
@@ -259,7 +259,7 @@ pub fn generate_ecdh_key_pair(c: EllipticCurveType) -> Result<EcPrivateKey, Tink
         EllipticCurveType::NistP256 => Ok(EcPrivateKey::NistP256(p256::NonZeroScalar::random(
             &mut csprng,
         ))),
-        _ => Err(format!("unsupported curve {:?}", c).into()),
+        _ => Err(format!("unsupported curve {c:?}").into()),
     }
 }
 

--- a/integration/awskms/src/aws_kms_client.rs
+++ b/integration/awskms/src/aws_kms_client.rs
@@ -94,11 +94,9 @@ impl AwsClient {
         kms: rusoto_kms::KmsClient,
     ) -> Result<AwsClient, TinkError> {
         if !uri_prefix.to_lowercase().starts_with(AWS_PREFIX) {
-            return Err(format!(
-                "uri_prefix must start with {}, but got {}",
-                AWS_PREFIX, uri_prefix
-            )
-            .into());
+            return Err(
+                format!("uri_prefix must start with {AWS_PREFIX}, but got {uri_prefix}").into(),
+            );
         }
 
         Ok(AwsClient {

--- a/integration/gcpkms/src/default_sa.rs
+++ b/integration/gcpkms/src/default_sa.rs
@@ -72,7 +72,7 @@ async fn on_gce_test() -> bool {
     // Method 1: check header returned by metadata server
     let http_result = async {
         let client = hyper::Client::new();
-        let uri = match format!("http://{}", METADATA_IP_STR).parse() {
+        let uri = match format!("http://{METADATA_IP_STR}").parse() {
             Ok(v) => v,
             Err(_) => return false,
         };
@@ -118,7 +118,7 @@ async fn get_gce_metadata(name: &str) -> Result<String, TinkError> {
     let uri = hyper::Uri::builder()
         .scheme("http")
         .authority(authority)
-        .path_and_query(format!("/computeMetadata/v1/{}", name))
+        .path_and_query(format!("/computeMetadata/v1/{name}"))
         .build()
         .map_err(|e| wrap_err("failed to build Uri", e))?;
     let client = hyper::Client::new();

--- a/integration/gcpkms/src/gcp_kms_aead.rs
+++ b/integration/gcpkms/src/gcp_kms_aead.rs
@@ -153,7 +153,7 @@ impl GcpAead {
             // Attempt to parse the response body as a GCP ErrorResponse object.
             let err_rsp: ErrorResponse = serde_json::from_reader(body.reader())
                 .map_err(|e| wrap_err("failed to parse JSON error response", e))?;
-            Err(format!("API failure {:?}", err_rsp).into())
+            Err(format!("API failure {err_rsp:?}").into())
         }
     }
 }

--- a/integration/gcpkms/src/gcp_kms_client.rs
+++ b/integration/gcpkms/src/gcp_kms_client.rs
@@ -33,7 +33,7 @@ impl GcpClient {
     /// `uri_prefix` prefix. `uri_prefix` must have the following format: `gcp-kms://[:path]`.
     pub fn new(uri_prefix: &str) -> Result<GcpClient, TinkError> {
         if !uri_prefix.to_lowercase().starts_with(GCP_PREFIX) {
-            return Err(format!("uri_prefix must start with {}", GCP_PREFIX).into());
+            return Err(format!("uri_prefix must start with {GCP_PREFIX}").into());
         }
 
         Ok(GcpClient {
@@ -49,7 +49,7 @@ impl GcpClient {
         credential_path: &std::path::Path,
     ) -> Result<GcpClient, TinkError> {
         if !uri_prefix.to_lowercase().starts_with(GCP_PREFIX) {
-            return Err(format!("uri_prefix must start with {}", GCP_PREFIX).into());
+            return Err(format!("uri_prefix must start with {GCP_PREFIX}").into());
         }
         let credential_path = credential_path.to_string_lossy();
         if credential_path.is_empty() {

--- a/mac/src/subtle/cmac.rs
+++ b/mac/src/subtle/cmac.rs
@@ -38,15 +38,13 @@ impl AesCmac {
         }
         if tag_size < MIN_TAG_LENGTH_IN_BYTES {
             return Err(format!(
-                "AesCmac: tag length {} is shorter than minimum tag length {}",
-                tag_size, MIN_TAG_LENGTH_IN_BYTES
+                "AesCmac: tag length {tag_size} is shorter than minimum tag length {MIN_TAG_LENGTH_IN_BYTES}",
             )
             .into());
         }
         if tag_size > MAX_TAG_LENGTH_IN_BYTES {
             return Err(format!(
-                "AesCmac: tag length {} is longer than maximum tag length {}",
-                tag_size, MIN_TAG_LENGTH_IN_BYTES
+                "AesCmac: tag length {tag_size} is longer than maximum tag length {MAX_TAG_LENGTH_IN_BYTES}",
             )
             .into());
         }
@@ -66,8 +64,7 @@ impl tink_core::Mac for AesCmac {
 pub fn validate_cmac_params(key_size: usize, tag_size: usize) -> Result<(), TinkError> {
     if key_size != RECOMMENDED_CMAC_KEY_SIZE_IN_BYTES {
         return Err(format!(
-            "Only {} sized keys are allowed with Tink's AES-CMAC",
-            RECOMMENDED_CMAC_KEY_SIZE_IN_BYTES
+            "Only {RECOMMENDED_CMAC_KEY_SIZE_IN_BYTES} sized keys are allowed with Tink's AES-CMAC",
         )
         .into());
     }

--- a/prf/src/subtle/aes_cmac.rs
+++ b/prf/src/subtle/aes_cmac.rs
@@ -65,8 +65,7 @@ impl AesCmacPrf {
 pub fn validate_aes_cmac_prf_params(key_size: usize) -> Result<(), TinkError> {
     if key_size != RECOMMENDED_KEY_SIZE {
         Err(format!(
-            "Recommended key size for AES-CMAC is {}, but {} given",
-            RECOMMENDED_KEY_SIZE, key_size
+            "Recommended key size for AES-CMAC is {RECOMMENDED_KEY_SIZE}, but {key_size} given",
         )
         .into())
     } else {
@@ -81,8 +80,7 @@ impl tink_core::Prf for AesCmacPrf {
     fn compute_prf(&self, data: &[u8], output_length: usize) -> Result<Vec<u8>, TinkError> {
         if output_length > AES_BLOCK_SIZE_IN_BYTES {
             return Err(format!(
-                "AesCmacPrf: output_length must be between 0 and {}",
-                AES_BLOCK_SIZE_IN_BYTES
+                "AesCmacPrf: output_length must be between 0 and {AES_BLOCK_SIZE_IN_BYTES}",
             )
             .into());
         }

--- a/prf/src/subtle/hkdf.rs
+++ b/prf/src/subtle/hkdf.rs
@@ -50,7 +50,7 @@ impl HkdfPrf {
             HashType::Sha512 => {
                 HkdfPrfVariant::Sha512(hkdf::Hkdf::<sha2::Sha512>::new(Some(salt), key))
             }
-            h => return Err(format!("HkdfPrf: unsupported hash {:?}", h).into()),
+            h => return Err(format!("HkdfPrf: unsupported hash {h:?}").into()),
         };
         Ok(HkdfPrf { prk })
     }

--- a/prf/src/subtle/hmac.rs
+++ b/prf/src/subtle/hmac.rs
@@ -65,7 +65,7 @@ impl HmacPrf {
                 Hmac::<sha2::Sha512>::new_from_slice(key)
                     .map_err(|_| "HmacPrf: invalid key size")?,
             ),
-            h => return Err(format!("HmacPrf: unsupported hash {:?}", h).into()),
+            h => return Err(format!("HmacPrf: unsupported hash {h:?}").into()),
         };
         let mac_size = match &mac {
             HmacPrfVariant::Sha1(_) => 20,

--- a/rinkey/src/main.rs
+++ b/rinkey/src/main.rs
@@ -40,7 +40,7 @@ impl FromStr for KeysetFormat {
         match variant.to_lowercase().as_ref() {
             "json" => Ok(KeysetFormat::Json),
             "binary" => Ok(KeysetFormat::Binary),
-            _ => Err(format!("Failed to parse format {}", variant)),
+            _ => Err(format!("Failed to parse format {variant}")),
         }
     }
 }
@@ -105,7 +105,7 @@ impl FromStr for KeyTemplate {
         if let Some(generator) = tink_core::registry::get_template_generator(template_name) {
             Ok(KeyTemplate(generator()))
         } else {
-            Err(format!("Unknown key template name {}", template_name))
+            Err(format!("Unknown key template name {template_name}",))
         }
     }
 }
@@ -405,7 +405,7 @@ fn list_keyset(opts: InOptions) {
 fn list_key_templates() {
     println!("The following key templates are supported:");
     for name in tink_core::registry::template_names() {
-        println!("{}", name);
+        println!("{name}");
     }
 }
 

--- a/signature/src/ecdsa_signer_key_manager.rs
+++ b/signature/src/ecdsa_signer_key_manager.rs
@@ -87,9 +87,7 @@ impl tink_core::registry::KeyManager for EcdsaSignerKeyManager {
                     public_key_data[point_len + 1..].to_vec(),
                 )
             }
-            _ => {
-                return Err(format!("EcdsaSignerKeyManager: unsupported curve {:?}", curve).into())
-            }
+            _ => return Err(format!("EcdsaSignerKeyManager: unsupported curve {curve:?}").into()),
         };
         let pub_key = tink_proto::EcdsaPublicKey {
             version: ECDSA_SIGNER_KEY_VERSION,

--- a/signature/src/subtle/ecdsa_common.rs
+++ b/signature/src/subtle/ecdsa_common.rs
@@ -54,7 +54,7 @@ pub fn validate_ecdsa_params(
                 return Err("invalid hash type, expect SHA-512".into());
             }
         }
-        _ => return Err(format!("unsupported curve: {:?}", curve).into()),
+        _ => return Err(format!("unsupported curve: {curve:?}").into()),
     }
     Ok(encoding)
 }

--- a/signature/src/subtle/ecdsa_signer.rs
+++ b/signature/src/subtle/ecdsa_signer.rs
@@ -66,7 +66,7 @@ impl EcdsaSigner {
                         .map_err(|e| wrap_err("EcdsaSigner: invalid private key", e))?,
                 )
             }
-            _ => return Err(format!("EcdsaSigner: unsupported curve {:?}", curve).into()),
+            _ => return Err(format!("EcdsaSigner: unsupported curve {curve:?}").into()),
         };
         Self::new_from_private_key(hash_alg, curve, encoding, priv_key)
     }

--- a/signature/src/subtle/ecdsa_verifier.rs
+++ b/signature/src/subtle/ecdsa_verifier.rs
@@ -58,7 +58,7 @@ impl EcdsaVerifier {
                     .map_err(|e| wrap_err("EcdsaVerifier: invalid point", e))?;
                 EcdsaPublicKey::NistP256(verify_key)
             }
-            _ => return Err(format!("EcdsaVerifier: unsupported curve {:?}", curve,).into()),
+            _ => return Err(format!("EcdsaVerifier: unsupported curve {curve:?}").into()),
         };
         Self::new_from_public_key(hash_alg, curve, encoding, public_key)
     }

--- a/streaming/src/subtle/mod.rs
+++ b/streaming/src/subtle/mod.rs
@@ -35,7 +35,7 @@ pub fn validate_aes_key_size(size_in_bytes: usize) -> Result<AesVariant, tink_co
     match size_in_bytes {
         16 => Ok(AesVariant::Aes128),
         32 => Ok(AesVariant::Aes256),
-        _ => Err(format!("invalid AES key size; want 16 or 32, got {}", size_in_bytes).into()),
+        _ => Err(format!("invalid AES key size; want 16 or 32, got {size_in_bytes}").into()),
     }
 }
 

--- a/streaming/src/subtle/noncebased.rs
+++ b/streaming/src/subtle/noncebased.rs
@@ -186,7 +186,7 @@ impl io::Write for Writer {
             let ciphertext = self
                 .segment_encrypter
                 .encrypt_segment(&self.plaintext[..pt_lim], &nonce)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("{:?}", e)))?;
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("{e:?}")))?;
             self.w.write_all(&ciphertext)?;
 
             // Ready to accumulate next segment.
@@ -428,7 +428,7 @@ impl io::Read for Reader {
         self.plaintext = self
             .segment_decrypter
             .decrypt_segment(&self.ciphertext[..segment], &nonce)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("{:?}", e)))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("{e:?}")))?;
 
         // Copy 1 byte remainder to the beginning of `self.ciphertext`.
         if !last_segment {

--- a/testing/src/aead_service.rs
+++ b/testing/src/aead_service.rs
@@ -38,7 +38,7 @@ impl proto::aead_server::Aead for AeadServerImpl {
         Ok(tonic::Response::new(proto::AeadEncryptResponse {
             result: Some(match closure() {
                 Ok(ct) => proto::aead_encrypt_response::Result::Ciphertext(ct),
-                Err(e) => proto::aead_encrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::aead_encrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -58,7 +58,7 @@ impl proto::aead_server::Aead for AeadServerImpl {
         Ok(tonic::Response::new(proto::AeadDecryptResponse {
             result: Some(match closure() {
                 Ok(pt) => proto::aead_decrypt_response::Result::Plaintext(pt),
-                Err(e) => proto::aead_decrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::aead_decrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }

--- a/testing/src/daead_service.rs
+++ b/testing/src/daead_service.rs
@@ -40,7 +40,7 @@ impl proto::deterministic_aead_server::DeterministicAead for DaeadServerImpl {
                 result: Some(match closure() {
                     Ok(ct) => proto::deterministic_aead_encrypt_response::Result::Ciphertext(ct),
                     Err(e) => {
-                        proto::deterministic_aead_encrypt_response::Result::Err(format!("{:?}", e))
+                        proto::deterministic_aead_encrypt_response::Result::Err(format!("{e:?}"))
                     }
                 }),
             },
@@ -65,7 +65,7 @@ impl proto::deterministic_aead_server::DeterministicAead for DaeadServerImpl {
                 result: Some(match closure() {
                     Ok(pt) => proto::deterministic_aead_decrypt_response::Result::Plaintext(pt),
                     Err(e) => {
-                        proto::deterministic_aead_decrypt_response::Result::Err(format!("{:?}", e))
+                        proto::deterministic_aead_decrypt_response::Result::Err(format!("{e:?}"))
                     }
                 }),
             },

--- a/testing/src/hybrid_service.rs
+++ b/testing/src/hybrid_service.rs
@@ -38,7 +38,7 @@ impl proto::hybrid_server::Hybrid for HybridServerImpl {
         Ok(tonic::Response::new(proto::HybridEncryptResponse {
             result: Some(match closure() {
                 Ok(ct) => proto::hybrid_encrypt_response::Result::Ciphertext(ct),
-                Err(e) => proto::hybrid_encrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::hybrid_encrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -59,7 +59,7 @@ impl proto::hybrid_server::Hybrid for HybridServerImpl {
         Ok(tonic::Response::new(proto::HybridDecryptResponse {
             result: Some(match closure() {
                 Ok(pt) => proto::hybrid_decrypt_response::Result::Plaintext(pt),
-                Err(e) => proto::hybrid_decrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::hybrid_decrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }

--- a/testing/src/keyset_service.rs
+++ b/testing/src/keyset_service.rs
@@ -63,7 +63,7 @@ impl proto::keyset_server::Keyset for KeysetServerImpl {
         Ok(tonic::Response::new(proto::KeysetGenerateResponse {
             result: Some(match closure() {
                 Ok(buf) => proto::keyset_generate_response::Result::Keyset(buf),
-                Err(e) => proto::keyset_generate_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::keyset_generate_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -89,7 +89,7 @@ impl proto::keyset_server::Keyset for KeysetServerImpl {
         Ok(tonic::Response::new(proto::KeysetPublicResponse {
             result: Some(match closure() {
                 Ok(buf) => proto::keyset_public_response::Result::PublicKeyset(buf),
-                Err(e) => proto::keyset_public_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::keyset_public_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -115,7 +115,7 @@ impl proto::keyset_server::Keyset for KeysetServerImpl {
         Ok(tonic::Response::new(proto::KeysetToJsonResponse {
             result: Some(match closure() {
                 Ok(json) => proto::keyset_to_json_response::Result::JsonKeyset(json),
-                Err(e) => proto::keyset_to_json_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::keyset_to_json_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -140,7 +140,7 @@ impl proto::keyset_server::Keyset for KeysetServerImpl {
         Ok(tonic::Response::new(proto::KeysetFromJsonResponse {
             result: Some(match closure() {
                 Ok(buf) => proto::keyset_from_json_response::Result::Keyset(buf),
-                Err(e) => proto::keyset_from_json_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::keyset_from_json_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }

--- a/testing/src/mac_service.rs
+++ b/testing/src/mac_service.rs
@@ -38,7 +38,7 @@ impl proto::mac_server::Mac for MacServerImpl {
         Ok(tonic::Response::new(proto::ComputeMacResponse {
             result: Some(match closure() {
                 Ok(mac) => proto::compute_mac_response::Result::MacValue(mac),
-                Err(e) => proto::compute_mac_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::compute_mac_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -57,7 +57,7 @@ impl proto::mac_server::Mac for MacServerImpl {
         Ok(tonic::Response::new(proto::VerifyMacResponse {
             err: match closure() {
                 Ok(_) => "".to_string(),
-                Err(e) => format!("{:?}", e),
+                Err(e) => format!("{e:?}"),
             },
         }))
     }

--- a/testing/src/prf_set_service.rs
+++ b/testing/src/prf_set_service.rs
@@ -45,7 +45,7 @@ impl proto::prf_set_server::PrfSet for PrfSetServerImpl {
         Ok(tonic::Response::new(proto::PrfSetKeyIdsResponse {
             result: Some(match closure() {
                 Ok(output) => proto::prf_set_key_ids_response::Result::Output(output),
-                Err(e) => proto::prf_set_key_ids_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::prf_set_key_ids_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -64,7 +64,7 @@ impl proto::prf_set_server::PrfSet for PrfSetServerImpl {
         Ok(tonic::Response::new(proto::PrfSetComputeResponse {
             result: Some(match closure() {
                 Ok(output) => proto::prf_set_compute_response::Result::Output(output),
-                Err(e) => proto::prf_set_compute_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::prf_set_compute_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }

--- a/testing/src/signature_service.rs
+++ b/testing/src/signature_service.rs
@@ -38,7 +38,7 @@ impl proto::signature_server::Signature for SignatureServerImpl {
         Ok(tonic::Response::new(proto::SignatureSignResponse {
             result: Some(match closure() {
                 Ok(sig) => proto::signature_sign_response::Result::Signature(sig),
-                Err(e) => proto::signature_sign_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::signature_sign_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -58,7 +58,7 @@ impl proto::signature_server::Signature for SignatureServerImpl {
         Ok(tonic::Response::new(proto::SignatureVerifyResponse {
             err: match closure() {
                 Ok(_) => "".to_string(),
-                Err(e) => format!("{:?}", e),
+                Err(e) => format!("{e:?}"),
             },
         }))
     }

--- a/testing/src/streaming_service.rs
+++ b/testing/src/streaming_service.rs
@@ -50,7 +50,7 @@ impl proto::streaming_aead_server::StreamingAead for StreamingAeadServerImpl {
         Ok(tonic::Response::new(proto::StreamingAeadEncryptResponse {
             result: Some(match closure() {
                 Ok(ct) => proto::streaming_aead_encrypt_response::Result::Ciphertext(ct),
-                Err(e) => proto::streaming_aead_encrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::streaming_aead_encrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }
@@ -79,7 +79,7 @@ impl proto::streaming_aead_server::StreamingAead for StreamingAeadServerImpl {
         Ok(tonic::Response::new(proto::StreamingAeadDecryptResponse {
             result: Some(match closure() {
                 Ok(pt) => proto::streaming_aead_decrypt_response::Result::Plaintext(pt),
-                Err(e) => proto::streaming_aead_decrypt_response::Result::Err(format!("{:?}", e)),
+                Err(e) => proto::streaming_aead_decrypt_response::Result::Err(format!("{e:?}")),
             }),
         }))
     }

--- a/tests/src/fakekms.rs
+++ b/tests/src/fakekms.rs
@@ -38,11 +38,9 @@ impl FakeClient {
     /// `key_uri` must have the following format: `fake-kms://<base64 encoded aead keyset>`.
     pub fn new(uri_prefix: &str) -> Result<Self, TinkError> {
         if !uri_prefix.to_lowercase().starts_with(FAKE_PREFIX) {
-            return Err(format!(
-                "UriPrefix must start with {}, but got {}",
-                FAKE_PREFIX, uri_prefix
-            )
-            .into());
+            return Err(
+                format!("UriPrefix must start with {FAKE_PREFIX}, but got {uri_prefix}").into(),
+            );
         }
         Ok(FakeClient {
             uri_prefix: uri_prefix.to_string(),

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -56,7 +56,7 @@ impl Default for DummyAeadKeyManager {
 
 impl tink_core::registry::KeyManager for DummyAeadKeyManager {
     fn primitive(&self, _serialized_key: &[u8]) -> Result<tink_core::Primitive, TinkError> {
-        Ok(tink_core::Primitive::Aead(Box::new(DummyAead::default())))
+        Ok(tink_core::Primitive::Aead(Box::<DummyAead>::default()))
     }
 
     fn new_key(&self, _serialized_key_format: &[u8]) -> Result<Vec<u8>, TinkError> {
@@ -124,7 +124,7 @@ impl DummySigner {
     pub fn new(name: &str) -> DummySigner {
         DummySigner {
             aead: DummyAead {
-                name: format!("dummy public key: {}", name),
+                name: format!("dummy public key: {name}"),
             },
         }
     }
@@ -148,7 +148,7 @@ impl DummyVerifier {
     pub fn new(name: &str) -> DummyVerifier {
         DummyVerifier {
             aead: DummyAead {
-                name: format!("dummy public key: {}", name),
+                name: format!("dummy public key: {name}"),
             },
         }
     }
@@ -190,7 +190,7 @@ impl tink_core::registry::KmsClient for DummyKmsClient {
     }
 
     fn get_aead(&self, _key_uri: &str) -> Result<Box<dyn tink_core::Aead>, TinkError> {
-        Ok(Box::new(DummyAead::default()))
+        Ok(Box::<DummyAead>::default())
     }
 }
 
@@ -987,7 +987,7 @@ pub fn expect_err<T, E: std::fmt::Debug>(result: Result<T, E>, err_msg: &str) {
     assert!(result.is_err(), "expected error containing '{}'", err_msg);
     let err = result.err();
     assert!(
-        format!("{:?}", err).contains(err_msg),
+        format!("{err:?}").contains(err_msg),
         "unexpected error {:?}, doesn't contain '{}'",
         err,
         err_msg
@@ -1004,7 +1004,7 @@ pub fn expect_err_for_case<T, E: std::fmt::Debug>(result: Result<T, E>, err_msg:
     );
     let err = result.err();
     assert!(
-        format!("{:?}", err).contains(err_msg),
+        format!("{err:?}").contains(err_msg),
         "{}: unexpected error {:?}, doesn't contain '{}'",
         name,
         err,

--- a/tests/src/testdata.rs
+++ b/tests/src/testdata.rs
@@ -59,7 +59,7 @@ pub fn key_template_proto(dir: &str, name: &str) -> Result<KeyTemplate, TinkErro
                 _ => tink_proto::OutputPrefixType::UnknownPrefix,
             } as i32;
         } else {
-            return Err(format!("Failed to parse text protobuf line: '{}'", line).into());
+            return Err(format!("Failed to parse text protobuf line: '{line}'").into());
         }
     }
 
@@ -85,7 +85,7 @@ fn escaped_string_to_bytes(input: &str) -> Result<Vec<u8>, TinkError> {
                     c.encode_utf8(&mut b);
                     output.push(b[0]);
                 }
-                _ => return Err(format!("Parse failure: invalid non-ASCII char {}", c).into()),
+                _ => return Err(format!("Parse failure: invalid non-ASCII char {c}").into()),
             },
             State::Escaped => match c {
                 'n' => {
@@ -120,7 +120,7 @@ fn escaped_string_to_bytes(input: &str) -> Result<Vec<u8>, TinkError> {
                 '1' => state = State::Octal1(1),
                 '2' => state = State::Octal1(2),
                 '3' => state = State::Octal1(3),
-                _ => return Err(format!("Parse failure: invalid escape char {}", c).into()),
+                _ => return Err(format!("Parse failure: invalid escape char {c}").into()),
             },
             State::Octal1(h) => match c {
                 '0' => state = State::Octal2(h << 3),
@@ -131,7 +131,7 @@ fn escaped_string_to_bytes(input: &str) -> Result<Vec<u8>, TinkError> {
                 '5' => state = State::Octal2((h << 3) + 5),
                 '6' => state = State::Octal2((h << 3) + 6),
                 '7' => state = State::Octal2((h << 3) + 7),
-                _ => return Err(format!("Parse failure: invalid first octal digit {}", c).into()),
+                _ => return Err(format!("Parse failure: invalid first octal digit {c}").into()),
             },
             State::Octal2(hi) => {
                 let lo = match c {
@@ -144,9 +144,7 @@ fn escaped_string_to_bytes(input: &str) -> Result<Vec<u8>, TinkError> {
                     '6' => 6,
                     '7' => 7,
                     _ => {
-                        return Err(
-                            format!("Parse failure: invalid second octal digit {}", c).into()
-                        )
+                        return Err(format!("Parse failure: invalid second octal digit {c}").into())
                     }
                 };
                 output.push((hi << 3) + lo);

--- a/tests/tests/aead/aead_factory_test.rs
+++ b/tests/tests/aead/aead_factory_test.rs
@@ -62,7 +62,7 @@ fn test_factory_multiple_keys() {
     let result = validate_aead_factory_cipher(a2.box_clone(), a.box_clone(), &expected_prefix);
     assert!(result.is_err(), "expect decryption to fail with random key");
     assert!(
-        format!("{:?}", result).contains("decryption failed"),
+        format!("{result:?}").contains("decryption failed"),
         "expect decryption to fail with random key: {:?}",
         result
     );

--- a/tests/tests/aead/aes_gcm_key_manager_test.rs
+++ b/tests/tests/aead/aes_gcm_key_manager_test.rs
@@ -105,7 +105,7 @@ fn test_aes_gcm_new_key_with_invalid_input() {
     for (i, serialized_format) in bad_formats.iter().enumerate() {
         key_manager
             .new_key(serialized_format)
-            .expect_err(&format!("expect an error in test case {}", i));
+            .expect_err(&format!("expect an error in test case {i}"));
     }
     // empty array
     key_manager
@@ -145,7 +145,7 @@ fn test_aes_gcm_new_key_data_with_invalid_input() {
     for (i, serialized_format) in bad_formats.iter().enumerate() {
         key_manager
             .new_key_data(serialized_format)
-            .expect_err(&format!("expect an error in test case {}", i));
+            .expect_err(&format!("expect an error in test case {i}"));
     }
     // empty array
     key_manager

--- a/tests/tests/aead/aes_gcm_siv_key_manager_test.rs
+++ b/tests/tests/aead/aes_gcm_siv_key_manager_test.rs
@@ -105,7 +105,7 @@ fn test_aes_gcm_siv_new_key_with_invalid_input() {
     for (i, serialized_format) in bad_formats.iter().enumerate() {
         key_manager
             .new_key(serialized_format)
-            .expect_err(&format!("expect an error in test case {}", i));
+            .expect_err(&format!("expect an error in test case {i}"));
     }
     // empty array
     key_manager
@@ -145,7 +145,7 @@ fn test_aes_gcm_siv_new_key_data_with_invalid_input() {
     for (i, serialized_format) in bad_formats.iter().enumerate() {
         key_manager
             .new_key_data(serialized_format)
-            .expect_err(&format!("expect an error in test case {}", i));
+            .expect_err(&format!("expect an error in test case {i}"));
     }
     // empty array
     key_manager

--- a/tests/tests/aead/chacha20poly1305_key_manager_test.rs
+++ b/tests/tests/aead/chacha20poly1305_key_manager_test.rs
@@ -154,7 +154,7 @@ fn validate_cha_cha20_poly1305_key(key: &tink_proto::ChaCha20Poly1305Key) -> Res
         )
         .into());
     }
-    if key.key_value.len() as usize != subtle::CHA_CHA20_KEY_SIZE {
+    if key.key_value.len() != subtle::CHA_CHA20_KEY_SIZE {
         return Err(format!(
             "incorrect key size: key_size != {}",
             subtle::CHA_CHA20_KEY_SIZE

--- a/tests/tests/aead/subtle/aead_test.rs
+++ b/tests/tests/aead/subtle/aead_test.rs
@@ -26,8 +26,8 @@ fn test_validate_aes_key_size() {
             _ => {
                 // Invalid key sizes.
                 let err =
-                    result.expect_err(&format!("invalid key size ({}) should not be accepted", i));
-                assert!(format!("{:?}", err).contains( "invalid AES key size; want 16 or 32") ,
+                    result.expect_err(&format!("invalid key size ({i}) should not be accepted"));
+                assert!(format!("{err:?}").contains( "invalid AES key size; want 16 or 32") ,
                         "wrong error message; want a String starting with \"invalid AES key size; want 16 or 32\", got {}", err);
             }
         }

--- a/tests/tests/aead/subtle/aes_ctr_test.rs
+++ b/tests/tests/aead/subtle/aes_ctr_test.rs
@@ -47,7 +47,7 @@ fn test_new_aes_ctr() {
                     Err(e) => e,
                     Ok(_) => panic!("AesCtr: unexpected success"),
                 };
-                assert!(format!("{}", err).contains(
+                assert!(format!("{err}").contains(
                     "AesCtr: invalid AES key size; want 16 or 32"),
                         "wrong error message; want a String starting with \"AesCtr: invalid AES key size; want 16 or 32\", got {}", err);
             }
@@ -69,7 +69,7 @@ fn test_new_aes_ctr() {
                 Err(e) => e,
                 Ok(_) => panic!("want error for invalid IV size"),
             };
-            assert!(format!("{:?}", err).contains("AesCtr: invalid IV size"));
+            assert!(format!("{err:?}").contains("AesCtr: invalid IV size"));
         }
     }
 }
@@ -175,8 +175,7 @@ fn test_encrypt_random_message() {
         assert_eq!(
             ciphertext.len(),
             message.len() + subtle::AES_CTR_MIN_IV_SIZE,
-            "invalid ciphertext length for i = {}",
-            i
+            "invalid ciphertext length for i = {i}",
         );
 
         let plaintext = stream
@@ -185,8 +184,7 @@ fn test_encrypt_random_message() {
 
         assert_eq!(
             plaintext, message,
-            "plaintext doesn't match message, i = {}",
-            i
+            "plaintext doesn't match message, i = {i}",
         );
     }
 }
@@ -206,8 +204,7 @@ fn test_encrypt_random_key_and_message() {
         assert_eq!(
             ciphertext.len(),
             message.len() + subtle::AES_CTR_MIN_IV_SIZE,
-            "invalid ciphertext length for i = {}",
-            i
+            "invalid ciphertext length for i = {i}",
         );
 
         let plaintext = stream
@@ -216,8 +213,7 @@ fn test_encrypt_random_key_and_message() {
 
         assert_eq!(
             plaintext, message,
-            "plaintext doesn't match message, i = {}",
-            i
+            "plaintext doesn't match message, i = {i}",
         );
     }
 }

--- a/tests/tests/aead/subtle/aes_gcm_siv_test.rs
+++ b/tests/tests/aead/subtle/aes_gcm_siv_test.rs
@@ -88,8 +88,7 @@ fn test_aes_gcm_siv_encrypt_decrypt() {
             });
             assert_eq!(
                 pt, decrypted,
-                "decrypted text and plaintext don't match: key_size {}, pt_size {}",
-                key_size, pt_size
+                "decrypted text and plaintext don't match: key_size {key_size}, pt_size {pt_size}",
             );
         }
     }
@@ -108,8 +107,7 @@ fn test_aes_gcm_siv_long_messages() {
             let decrypted = a.decrypt(&ct, &ad).unwrap();
             assert_eq!(
                 pt, decrypted,
-                "decrypted text and plaintext don't match: key_size {}, pt_size {}",
-                key_size, pt_size
+                "decrypted text and plaintext don't match: key_size {key_size}, pt_size {pt_size}",
             );
         }
         pt_size += 9 * pt_size / 11
@@ -129,8 +127,7 @@ fn test_aes_gcm_siv_modify_ciphertext() {
         for j in 0..8 {
             ct[i] ^= 1 << j;
             a.decrypt(&ct, &ad).expect_err(&format!(
-                "expect an error when flipping bit of ciphertext: byte {}, bit {}",
-                i, j
+                "expect an error when flipping bit of ciphertext: byte {i}, bit {j}",
             ));
             ct[i] = tmp;
         }
@@ -138,8 +135,7 @@ fn test_aes_gcm_siv_modify_ciphertext() {
     // truncated ciphertext
     for i in 1..ct.len() {
         a.decrypt(&ct[..i], &ad).expect_err(&format!(
-            "expect an error ciphertext is truncated until byte {}",
-            i
+            "expect an error ciphertext is truncated until byte {i}",
         ));
     }
     // modify additional authenticated data
@@ -148,8 +144,7 @@ fn test_aes_gcm_siv_modify_ciphertext() {
         for j in 0..8 {
             ad[i] ^= 1 << j;
             a.decrypt(&ct, &ad).expect_err(&format!(
-                "expect an error when flipping bit of ad: byte {}, bit {}",
-                i, j
+                "expect an error when flipping bit of ad: byte {i}, bit {j}",
             ));
             ad[i] = tmp;
         }
@@ -181,7 +176,7 @@ fn test_aes_gcm_siv_random_nonce_produces_different_ciphertexts() {
 #[test]
 fn test_aes_gcm_siv_wycheproof_cases() {
     let filename = "testvectors/aes_gcm_siv_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: wycheproof::TestData = serde_json::from_slice(&bytes).unwrap();
     assert_eq!("AES-GCM-SIV", data.suite.algorithm);

--- a/tests/tests/aead/subtle/aes_gcm_test.rs
+++ b/tests/tests/aead/subtle/aes_gcm_test.rs
@@ -76,8 +76,7 @@ fn test_aes_gcm_encrypt_decrypt() {
             });
             assert_eq!(
                 pt, decrypted,
-                "decrypted text and plaintext don't match: key_size {}, pt_size {}",
-                key_size, pt_size
+                "decrypted text and plaintext don't match: key_size {key_size}, pt_size {pt_size}",
             );
         }
     }
@@ -96,8 +95,7 @@ fn test_aes_gcm_long_messages() {
             let decrypted = a.decrypt(&ct, &ad).unwrap();
             assert_eq!(
                 pt, decrypted,
-                "decrypted text and plaintext don't match: key_size {}, pt_size {}",
-                key_size, pt_size
+                "decrypted text and plaintext don't match: key_size {key_size}, pt_size {pt_size}",
             );
         }
         pt_size += 9 * pt_size / 11
@@ -117,8 +115,7 @@ fn test_aes_gcm_modify_ciphertext() {
         for j in 0..8 {
             ct[i] ^= 1 << j;
             a.decrypt(&ct, &ad).expect_err(&format!(
-                "expect an error when flipping bit of ciphertext: byte {}, bit {}",
-                i, j
+                "expect an error when flipping bit of ciphertext: byte {i}, bit {j}",
             ));
             ct[i] = tmp;
         }
@@ -126,8 +123,7 @@ fn test_aes_gcm_modify_ciphertext() {
     // truncated ciphertext
     for i in 1..ct.len() {
         a.decrypt(&ct[..i], &ad).expect_err(&format!(
-            "expect an error ciphertext is truncated until byte {}",
-            i
+            "expect an error ciphertext is truncated until byte {i}",
         ));
     }
     // modify additional authenticated data
@@ -136,8 +132,7 @@ fn test_aes_gcm_modify_ciphertext() {
         for j in 0..8 {
             ad[i] ^= 1 << j;
             a.decrypt(&ct, &ad).expect_err(&format!(
-                "expect an error when flipping bit of ad: byte {}, bit {}",
-                i, j
+                "expect an error when flipping bit of ad: byte {i}, bit {j}",
             ));
             ad[i] = tmp;
         }
@@ -169,7 +164,7 @@ fn test_aes_gcm_random_nonce() {
 #[test]
 fn test_aes_gcm_vectors() {
     let filename = "testvectors/aes_gcm_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: wycheproof::TestData = serde_json::from_slice(&bytes).unwrap();
     assert_eq!("AES-GCM", data.suite.algorithm);

--- a/tests/tests/aead/subtle/chacha20poly1305_test.rs
+++ b/tests/tests/aead/subtle/chacha20poly1305_test.rs
@@ -221,7 +221,7 @@ fn test_cha_cha20_poly1305_invalid_key() {
 #[test]
 fn test_cha_cha20_poly1305_wycheproof_vectors() {
     let filename = "testvectors/chacha20_poly1305_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
     assert_eq!("CHACHA20-POLY1305", data.suite.algorithm);

--- a/tests/tests/aead/subtle/encrypt_then_authenticate_test.rs
+++ b/tests/tests/aead/subtle/encrypt_then_authenticate_test.rs
@@ -223,8 +223,7 @@ fn test_eta_decrypt_modified_ciphertext() {
             "modified ciphertext shouldn't be the same as original"
         );
         cipher.decrypt(&modct, &aad[..]).expect_err(&format!(
-            "successfully decrypted modified ciphertext (i = {})",
-            i
+            "successfully decrypted modified ciphertext (i = {i})",
         ));
         // Restore the modified byte.
         modct[i / 8] = b;
@@ -243,8 +242,7 @@ fn test_eta_decrypt_modified_ciphertext() {
             "modified aad shouldn't be the same as aad"
         );
         cipher.decrypt(&ciphertext, &modaad).expect_err(&format!(
-            "successfully decrypted with modified aad (i = {})",
-            i
+            "successfully decrypted with modified aad (i = {i})",
         ));
         // Restore the modified byte.
         modaad[i / 8] = b
@@ -255,8 +253,7 @@ fn test_eta_decrypt_modified_ciphertext() {
         cipher
             .decrypt(&ciphertext[..(ciphertext.len() - i)], aad)
             .expect_err(&format!(
-                "successfully decrypted truncated ciphertext (i = {})",
-                i
+                "successfully decrypted truncated ciphertext (i = {i})",
             ));
     }
 }

--- a/tests/tests/aead/subtle/xchacha20poly1305_test.rs
+++ b/tests/tests/aead/subtle/xchacha20poly1305_test.rs
@@ -222,7 +222,7 @@ fn test_cha_cha20_poly1305_invalid_key() {
 #[test]
 fn test_x_cha_cha20_poly1305_wycheproof_vectors() {
     let filename = "testvectors/xchacha20_poly1305_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
     assert_eq!("XCHACHA20-POLY1305", data.suite.algorithm);

--- a/tests/tests/aead/xchacha20poly1305_key_manager_test.rs
+++ b/tests/tests/aead/xchacha20poly1305_key_manager_test.rs
@@ -156,7 +156,7 @@ fn validate_x_cha_cha20_poly1305_key(
         )
         .into());
     }
-    if key.key_value.len() as usize != subtle::CHA_CHA20_KEY_SIZE {
+    if key.key_value.len() != subtle::CHA_CHA20_KEY_SIZE {
         return Err(format!(
             "incorrect key size: keySize != {}",
             subtle::CHA_CHA20_KEY_SIZE

--- a/tests/tests/awskms/aws_kms_client_test.rs
+++ b/tests/tests/awskms/aws_kms_client_test.rs
@@ -32,7 +32,7 @@ fn test_client_debug() {
     let uri_prefix =
         "aws-kms://arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f";
     let client = AwsClient::new(uri_prefix).unwrap();
-    assert_eq!(format!("{:?}", client), "AwsClient { key_uri_prefix: \"aws-kms://arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f\" }");
+    assert_eq!(format!("{client:?}"), "AwsClient { key_uri_prefix: \"aws-kms://arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f\" }");
 }
 
 #[test]

--- a/tests/tests/core/keyset/binary_io_test.rs
+++ b/tests/tests/core/keyset/binary_io_test.rs
@@ -34,8 +34,7 @@ fn test_binary_io_unencrypted() {
     let ks2 = r.read().expect("cannot read keyset");
     assert_eq!(
         ks1, ks2,
-        "written keyset ({:?}) doesn't match read keyset ({:?})",
-        ks1, ks2
+        "written keyset ({ks1:?}) doesn't match read keyset ({ks2:?})",
     );
 }
 
@@ -57,8 +56,7 @@ fn test_binary_io_encrypted() {
     let kse2 = r.read_encrypted().expect("cannot read encrypted keyset");
     assert_eq!(
         kse1, kse2,
-        "written encrypted keyset ({:?}) doesn't match read encrypted keyset ({:?})",
-        kse1, kse2
+        "written encrypted keyset ({kse1:?}) doesn't match read encrypted keyset ({kse2:?})",
     );
 }
 

--- a/tests/tests/core/keyset/handle_test.rs
+++ b/tests/tests/core/keyset/handle_test.rs
@@ -73,7 +73,7 @@ fn test_read() {
     let h = insecure::new_handle(ks).unwrap();
 
     // Also check that debug output of handle doesn't include key material.
-    let debug_output = format!("{:?}", h);
+    let debug_output = format!("{h:?}");
     assert!(!debug_output.contains("42"));
 
     let mem_keyset = &mut tink_core::keyset::MemReaderWriter::default();
@@ -82,9 +82,7 @@ fn test_read() {
     assert_eq!(
         insecure::keyset_material(&h),
         insecure::keyset_material(&h2),
-        "Decrypt failed: got {:?}, want {:?}",
-        h2,
-        h
+        "Decrypt failed: got {h2:?}, want {h:?}",
     );
 }
 
@@ -111,9 +109,7 @@ fn test_read_with_associated_data() {
     assert_eq!(
         insecure::keyset_material(&h),
         insecure::keyset_material(&h2),
-        "Decrypt failed: got {:?}, want {:?}",
-        h2,
-        h
+        "Decrypt failed: got {h2:?}, want {h:?}",
     );
 }
 #[test]
@@ -160,9 +156,7 @@ fn test_read_with_no_secrets() {
     assert_eq!(
         insecure::keyset_material(&h),
         insecure::keyset_material(&h2),
-        "Decrypt failed: got {:?}, want {:?}",
-        h2,
-        h
+        "Decrypt failed: got {h2:?}, want {h:?}",
     );
 }
 

--- a/tests/tests/core/keyset/json_io_test.rs
+++ b/tests/tests/core/keyset/json_io_test.rs
@@ -36,8 +36,7 @@ fn test_json_io_unencrypted() {
     let ks2 = r.read().expect("cannot read keyset");
     assert_eq!(
         ks1, ks2,
-        "written keyset ({:?}) doesn't match read keyset ({:?})",
-        ks1, ks2
+        "written keyset ({ks1:?}) doesn't match read keyset ({ks2:?})",
     );
 }
 
@@ -177,7 +176,7 @@ fn test_json_reader_negative_ids() {
             }}
          ]
       }}"#,
-        base64::encode(&gcm_key),
+        base64::encode(gcm_key),
     );
     let mut buf = Vec::new();
     buf.write_all(json_keyset.as_bytes()).unwrap();
@@ -243,8 +242,7 @@ fn test_json_io_encrypted() {
     let kse2 = r.read_encrypted().expect("cannot read encrypted keyset");
     assert_eq!(
         kse1, kse2,
-        "written encrypted keyset ({:?}) doesn't match read encrypted keyset ({:?})",
-        kse1, kse2
+        "written encrypted keyset ({kse1:?}) doesn't match read encrypted keyset ({kse2:?})",
     );
 }
 

--- a/tests/tests/core/primitiveset/mod.rs
+++ b/tests/tests/core/primitiveset/mod.rs
@@ -47,7 +47,7 @@ fn test_primitive_set_basic() {
     let mut entries = Vec::with_capacity(keys.len());
     for i in 0..keys.len() {
         let mac = Box::new(DummyMac {
-            name: format!("Mac#{}", i),
+            name: format!("Mac#{i}"),
         });
         macs.push(mac);
         entries.push(ps.add(Primitive::Mac(macs[i].clone()), &keys[i]).unwrap());

--- a/tests/tests/core/subtle/hkdf_hmac_test.rs
+++ b/tests/tests/core/subtle/hkdf_hmac_test.rs
@@ -110,11 +110,11 @@ fn test_hkdf_basic() {
         let i = hex::decode(test.info).unwrap();
 
         let result = compute_hkdf(test.hash_alg, &k, &s, &i, test.tag_size)
-            .map_err(|e| format!("mac computation failed in test case {}: {}", ti, e))
+            .map_err(|e| format!("mac computation failed in test case {ti}: {e}"))
             .unwrap();
         let r = hex::encode(result);
 
-        println!("Test no: {}", ti);
+        println!("Test no: {ti}");
         println!("Length of tag {}", test.tag_size);
         println!("Length of result {}", r.len());
         println!("Length of expected: {}\n\n", test.expected_kdf.len());
@@ -131,7 +131,7 @@ fn test_new_hmac_with_invalid_input() {
     // invalid hash algorithm
     if let Err(e) = compute_hkdf(HashType::UnknownHash, &get_random_bytes(16), &[], &[], 32) {
         assert!(
-            format!("{}", e).contains("invalid hash algorithm"),
+            format!("{e}").contains("invalid hash algorithm"),
             "expect error with 'invalid hash algorithm', got '{}'",
             e
         );
@@ -142,7 +142,7 @@ fn test_new_hmac_with_invalid_input() {
     // tag too short
     if let Err(e) = compute_hkdf(HashType::Sha256, &get_random_bytes(16), &[], &[], 9) {
         assert!(
-            format!("{}", e).contains("tag size too small"),
+            format!("{e}").contains("tag size too small"),
             "expect error with 'tag size too small', got '{}'",
             e
         );
@@ -153,7 +153,7 @@ fn test_new_hmac_with_invalid_input() {
     // tag too big
     if let Err(e) = compute_hkdf(HashType::Sha1, &get_random_bytes(16), &[], &[], 5101) {
         assert!(
-            format!("{}", e).contains("tag size too big"),
+            format!("{e}").contains("tag size too big"),
             "expect error with 'tag size too big', got '{}'",
             e
         );
@@ -162,7 +162,7 @@ fn test_new_hmac_with_invalid_input() {
     }
     if let Err(e) = compute_hkdf(HashType::Sha256, &get_random_bytes(16), &[], &[], 8162) {
         assert!(
-            format!("{}", e).contains("tag size too big"),
+            format!("{e}").contains("tag size too big"),
             "expect error with 'tag size too big', got '{}'",
             e
         );
@@ -171,7 +171,7 @@ fn test_new_hmac_with_invalid_input() {
     }
     if let Err(e) = compute_hkdf(HashType::Sha512, &get_random_bytes(16), &[], &[], 16323) {
         assert!(
-            format!("{}", e).contains("tag size too big"),
+            format!("{e}").contains("tag size too big"),
             "expect error with 'tag size too big', got '{}'",
             e
         );

--- a/tests/tests/daead/aes_siv_test.rs
+++ b/tests/tests/daead/aes_siv_test.rs
@@ -221,7 +221,7 @@ struct TestCase {
 #[test]
 fn test_aes_siv_wycheproof_vectors() {
     let filename = "testvectors/aes_siv_cmac_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
 

--- a/tests/tests/gcpkms/integration_test.rs
+++ b/tests/tests/gcpkms/integration_test.rs
@@ -24,7 +24,7 @@ fn gcpkms_example() {
     tink_aead::init();
     let key_uri = key_uri(); // something like "gcp-kms://......";
     let creds = cred_file(); // e.g. "/mysecurestorage/credentials.json";
-    println!("Running with key {} and creds {:?}", key_uri, creds);
+    println!("Running with key {key_uri} and creds {creds:?}");
 
     let gcp_client = if creds.components().next().is_some() {
         tink_gcpkms::GcpClient::new_with_credentials(&key_uri, &creds)

--- a/tests/tests/hybrid/ecies_aead_hkdf_dem_helper_test.rs
+++ b/tests/tests/hybrid/ecies_aead_hkdf_dem_helper_test.rs
@@ -71,8 +71,7 @@ fn test_cipher_key_size() {
         assert_eq!(
             r_dem.get_symmetric_key_size(),
             *l,
-            "incorrect key size for {:?} template",
-            c,
+            "incorrect key size for {c:?} template",
         );
     }
 }

--- a/tests/tests/hybrid/subtle/elliptic_curves_test.rs
+++ b/tests/tests/hybrid/subtle/elliptic_curves_test.rs
@@ -644,12 +644,11 @@ fn test_point_encode() {
         )
         .unwrap();
         let encoded_point = subtle::point_encode(tc.curve, tc.point_format, &pub_key)
-            .unwrap_or_else(|e| panic!("error in point encoding in test case {} : {:?}", i, e,));
+            .unwrap_or_else(|e| panic!("error in point encoding in test case {i} : {:?}", e));
         let want = hex::decode(tc.encoded).unwrap();
         assert_eq!(
             encoded_point, want,
-            "mismatch point encoding in test case {}",
-            i
+            "mismatch point encoding in test case {i}",
         );
 
         // Check some invalid variants are rejected.
@@ -681,8 +680,7 @@ fn test_point_decode() {
         assert_eq!(
             pub_key.x_y_bytes().unwrap(),
             spub_key.x_y_bytes().unwrap(),
-            "mismatch point decoding in test case {}",
-            i
+            "mismatch point decoding in test case {i}",
         );
 
         // Check some invalid variants are rejected.
@@ -754,7 +752,7 @@ fn convert_x509_public_key(
                 .map_err(|_e| "failed to decode X509 public key")?;
             Ok(subtle::EcPublicKey::NistP256(*pub_key.as_affine()))
         }
-        _ => Err(format!("unsupported curve {:?}", curve).into()),
+        _ => Err(format!("unsupported curve {curve:?}").into()),
     }
 }
 
@@ -819,8 +817,8 @@ fn test_ec_wycheproof_cases() {
 }
 
 fn wycheproof_test(filename: &str) {
-    println!("wycheproof file 'testvectors/{}'", filename);
-    let bytes = tink_tests::wycheproof_data(&format!("testvectors/{}", filename));
+    println!("wycheproof file 'testvectors/{filename}'");
+    let bytes = tink_tests::wycheproof_data(&format!("testvectors/{filename}"));
     let data: EcdhSuite = serde_json::from_slice(&bytes).unwrap();
     let mut skipped_curves = HashSet::new();
     for g in &data.test_groups {
@@ -829,12 +827,12 @@ fn wycheproof_test(filename: &str) {
         // if curve == EllipticCurveType::UnknownCurve {
         if curve != EllipticCurveType::NistP256 {
             if !skipped_curves.contains(&curve) {
-                println!("skipping tests for unsupported curve {:?}", curve);
+                println!("skipping tests for unsupported curve {curve:?}");
                 skipped_curves.insert(curve);
             }
             continue;
         }
-        println!("   curve: {:?}", curve);
+        println!("   curve: {curve:?}");
 
         for tc in &g.tests {
             let case_name = format!(
@@ -871,8 +869,7 @@ fn wycheproof_test(filename: &str) {
                         });
                     assert_eq!(
                         shared, tc.shared,
-                        "{}: valid test case, incorrect shared secret",
-                        case_name
+                        "{case_name}: valid test case, incorrect shared secret",
                     );
                 }
                 WycheproofResult::Invalid => {
@@ -911,8 +908,7 @@ fn wycheproof_test(filename: &str) {
                     let shared = shared_result.unwrap();
                     assert_eq!(
                         shared, tc.shared,
-                        "{}: acceptable test case, incorrect shared secret",
-                        case_name
+                        "{case_name}: acceptable test case, incorrect shared secret",
                     );
                 }
             }

--- a/tests/tests/mac/aes_cmac_key_manager_test.rs
+++ b/tests/tests/mac/aes_cmac_key_manager_test.rs
@@ -122,14 +122,12 @@ fn test_new_key_data_cmac_basic() {
         assert_eq!(
             key_data.type_url,
             tink_tests::AES_CMAC_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::Symmetric as i32,
-            "incorrect key material type in test case {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key =
             tink_proto::AesCmacKey::decode(key_data.value.as_ref()).expect("invalid key value");

--- a/tests/tests/mac/hmac_key_manager_test.rs
+++ b/tests/tests/mac/hmac_key_manager_test.rs
@@ -119,18 +119,16 @@ fn test_new_key_data_basic() {
         let serialized_format = proto_encode(test_format);
         let key_data = km
             .new_key_data(&serialized_format)
-            .unwrap_or_else(|e| panic!("unexpected error in test case {}: {:?}", i, e));
+            .unwrap_or_else(|e| panic!("unexpected error in test case {i}: {:?}", e));
         assert_eq!(
             key_data.type_url,
             tink_tests::HMAC_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::Symmetric as i32,
-            "incorrect key material type in test case {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key = tink_proto::HmacKey::decode(key_data.value.as_ref()).expect("invalid key value");
         validate_hmac_key(test_format, &key).expect("invalid key");

--- a/tests/tests/mac/subtle/cmac_test.rs
+++ b/tests/tests/mac/subtle/cmac_test.rs
@@ -68,7 +68,7 @@ pub struct TestCase {
 #[test]
 fn test_vectors_wycheproof() {
     let filename = "testvectors/aes_cmac_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
 

--- a/tests/tests/mac/subtle/hmac_test.rs
+++ b/tests/tests/mac/subtle/hmac_test.rs
@@ -65,8 +65,7 @@ fn test_hmac_basic() {
         assert_eq!(
             hex::encode(&mac),
             test.expected_mac[..(test.tag_size * 2)],
-            "incorrect mac in test case {}",
-            i
+            "incorrect mac in test case {i}",
         );
         cipher
             .verify_mac(&mac, test.data)

--- a/tests/tests/prf/aes_cmac_prf_key_manager_test.rs
+++ b/tests/tests/prf/aes_cmac_prf_key_manager_test.rs
@@ -118,18 +118,16 @@ fn test_new_key_data_cmac_basic() {
         let serialized_format = proto_encode(test_format);
         let key_data = km
             .new_key_data(&serialized_format)
-            .unwrap_or_else(|e| panic!("unexpected error in test case {}: {:?}", i, e));
+            .unwrap_or_else(|e| panic!("unexpected error in test case {i}: {:?}", e));
         assert_eq!(
             key_data.type_url,
             tink_tests::AES_CMAC_PRF_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::Symmetric as i32,
-            "incorrect key material type in test case {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key =
             tink_proto::AesCmacPrfKey::decode(key_data.value.as_ref()).expect("invalid key value");

--- a/tests/tests/prf/hkdf_prf_key_manager_test.rs
+++ b/tests/tests/prf/hkdf_prf_key_manager_test.rs
@@ -126,14 +126,12 @@ fn test_new_key_data_hkdf_basic() {
         assert_eq!(
             key_data.type_url,
             tink_tests::HKDF_PRF_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::Symmetric as i32,
-            "incorrect key material type in test case {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key =
             tink_proto::HkdfPrfKey::decode(key_data.value.as_ref()).expect("invalid key value");

--- a/tests/tests/prf/hmac_prf_key_manager_test.rs
+++ b/tests/tests/prf/hmac_prf_key_manager_test.rs
@@ -121,18 +121,16 @@ fn test_new_key_data_hmac_basic() {
         let serialized_format = proto_encode(test_format);
         let key_data = km
             .new_key_data(&serialized_format)
-            .unwrap_or_else(|e| panic!("unexpected error in test case {}: {:?}", i, e));
+            .unwrap_or_else(|e| panic!("unexpected error in test case {i}: {:?}", e));
         assert_eq!(
             key_data.type_url,
             tink_tests::HMAC_PRF_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::Symmetric as i32,
-            "incorrect key material type in test case {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key =
             tink_proto::HmacPrfKey::decode(key_data.value.as_ref()).expect("invalid key value");

--- a/tests/tests/prf/integration_test.rs
+++ b/tests/tests/prf/integration_test.rs
@@ -29,5 +29,5 @@ fn example() {
     let output = ps.compute_primary_prf(msg, 16).unwrap();
 
     println!("Message: {}", std::str::from_utf8(msg).unwrap());
-    println!("Redacted: {}", base64::encode(&output));
+    println!("Redacted: {}", base64::encode(output));
 }

--- a/tests/tests/prf/subtle/aes_cmac_test.rs
+++ b/tests/tests/prf/subtle/aes_cmac_test.rs
@@ -77,7 +77,7 @@ pub struct TestCase {
 #[test]
 fn test_aes_cmac_prf_wycheproof_cases() {
     let filename = "testvectors/aes_cmac_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
 

--- a/tests/tests/prf/subtle/hkdf_test.rs
+++ b/tests/tests/prf/subtle/hkdf_test.rs
@@ -143,9 +143,9 @@ struct HkdfTestCase {
 #[test]
 fn test_hkdf_prf_wycheproof_cases() {
     for hash in &[HashType::Sha1, HashType::Sha256, HashType::Sha512] {
-        let hash_name = format!("{:?}", hash);
+        let hash_name = format!("{hash:?}");
         let filename = format!("testvectors/hkdf_{}_test.json", hash_name.to_lowercase());
-        println!("wycheproof file '{}' hash {}", filename, hash_name);
+        println!("wycheproof file '{filename}' hash {hash_name}");
         let bytes = tink_tests::wycheproof_data(&filename);
         let data: HkdfTestData = serde_json::from_slice(&bytes).unwrap();
 

--- a/tests/tests/prf/subtle/hmac_test.rs
+++ b/tests/tests/prf/subtle/hmac_test.rs
@@ -105,9 +105,9 @@ fn test_hmac_prf_wycheproof_cases() {
         HashType::Sha256,
         HashType::Sha512,
     ] {
-        let hash_name = format!("{:?}", hash);
+        let hash_name = format!("{hash:?}");
         let filename = format!("testvectors/hmac_{}_test.json", hash_name.to_lowercase());
-        println!("wycheproof file '{}' hash {}", filename, hash_name);
+        println!("wycheproof file '{filename}' hash {hash_name}");
         let bytes = tink_tests::wycheproof_data(&filename);
         let data: TestData = serde_json::from_slice(&bytes).unwrap();
 

--- a/tests/tests/signature/ecdsa_signer_key_manager_test.rs
+++ b/tests/tests/signature/ecdsa_signer_key_manager_test.rs
@@ -197,8 +197,7 @@ fn test_ecdsa_sign_new_key_multiple_times() {
         assert_eq!(
             keys.len(),
             n_test * 2,
-            "key is repeated with params: {:?}",
-            params
+            "key is repeated with params: {params:?}",
         );
     }
 }
@@ -224,14 +223,12 @@ fn test_ecdsa_sign_new_key_data_basic() {
         assert_eq!(
             key_data.type_url,
             tink_tests::ECDSA_SIGNER_TYPE_URL,
-            "incorrect type url in test case {}",
-            i
+            "incorrect type url in test case {i}",
         );
         assert_eq!(
             key_data.key_material_type,
             tink_proto::key_data::KeyMaterialType::AsymmetricPrivate as i32,
-            "incorrect key material type in test case  {}",
-            i
+            "incorrect key material type in test case {i}",
         );
         let key = tink_proto::EcdsaPrivateKey::decode(key_data.value.as_ref())
             .unwrap_or_else(|e| panic!("unexpected error in test case {}: {:?}", i, e));

--- a/tests/tests/signature/subtle/ecdsa_signer_verifier_test.rs
+++ b/tests/tests/signature/subtle/ecdsa_signer_verifier_test.rs
@@ -240,11 +240,8 @@ fn test_ecdsa_wycheproof_cases() {
 }
 
 fn wycheproof_test(filename: &str, encoding: EcdsaSignatureEncoding) {
-    println!(
-        "wycheproof file 'testvectors/{}', encoding '{:?}'",
-        filename, encoding
-    );
-    let bytes = tink_tests::wycheproof_data(&format!("testvectors/{}", filename));
+    println!("wycheproof file 'testvectors/{filename}', encoding '{encoding:?}'",);
+    let bytes = tink_tests::wycheproof_data(&format!("testvectors/{filename}"));
     let data: TestData = serde_json::from_slice(&bytes).unwrap();
     let mut skipped_hashes = HashSet::new();
     let mut skipped_curves = HashSet::new();

--- a/tests/tests/signature/subtle/ed25519_signer_verifier_test.rs
+++ b/tests/tests/signature/subtle/ed25519_signer_verifier_test.rs
@@ -192,7 +192,7 @@ struct TestCaseEd25519 {
 #[test]
 fn test_ed25519_wycheproof_cases() {
     let filename = "testvectors/eddsa_test.json";
-    println!("wycheproof file '{}'", filename);
+    println!("wycheproof file '{filename}'");
     let bytes = tink_tests::wycheproof_data(filename);
     let data: TestDataEd25519 = serde_json::from_slice(&bytes).unwrap();
     for g in &data.test_groups {
@@ -299,6 +299,6 @@ fn test_ed25519_point_on_curve() {
     ];
     let result = ed25519_dalek::PublicKey::from_bytes(&public_key_bytes);
     assert!(result.is_err());
-    assert!(format!("{:?}", result).contains("Cannot decompress"));
+    assert!(format!("{result:?}").contains("Cannot decompress"));
     assert!(Ed25519Verifier::new(&public_key_bytes).is_err());
 }

--- a/tests/tests/streaming/factory_test.rs
+++ b/tests/tests/streaming/factory_test.rs
@@ -61,7 +61,7 @@ fn validate_factory_cipher(
             t,
             32,
         )
-        .map_err(|e| wrap_err(&format!("failed plaintext-size={}", t), e))?;
+        .map_err(|e| wrap_err(&format!("failed plaintext-size={t}"), e))?;
     }
     Ok(())
 }


### PR DESCRIPTION
This will be a Clippy warning in future.

Also fix a few other Clippy future warnings:
- Use Box::default()
- Drop unneeded casts
- Drop unneeded &