### PR TITLE
tests: drop cfg!(overflow_checks) gate

### DIFF
--- a/tests/tests/prf/subtle/hkdf_test.rs
+++ b/tests/tests/prf/subtle/hkdf_test.rs
@@ -303,8 +303,7 @@ fn test_hkdf_prf_output_length() {
         });
         // If overflow checks are enabled (which they are by default for tests),
         // this loop runs too slow, so only test every 10th length.
-        let stride: usize = if cfg!(overflow_checks) { 1 } else { 10 };
-        for i in (0..=(length * 255)).step_by(stride) {
+        for i in (0..=(length * 255)).step_by(10) {
             let output = prf.compute_prf(&[0x01, 0x02], i).unwrap_or_else(|e| {
                 panic!(
                     "Expected to be able to compute HKDF {:?} PRF with {} output length: {:?}",


### PR DESCRIPTION
This was wrong in a couple of ways -- setting the overflow-checks codegen option didn't actually set cfg!(overflow_checks), and moreover the test was back to front.

Recent beta compilers do now set cfg!(overflow_checks), and emit an error because use of it is unstable, so remove it.