### PR TITLE
core/src/utils.rs:  Make TinkError `Send`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## 0.2.6 - TBD
+## 0.3.0 - TBD
 
 - Increase MSRV to 1.65.0
 - Upgrade dependencies
+- Make `tink_core::TinkError` implement `Send`; this is a breaking change, as it requires a `Send` bound on wrapped errors
 
 ## 0.2.5 - 2023-03-14
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -26,7 +26,7 @@ use std::error::Error;
 #[derive(Debug)]
 pub struct TinkError {
     msg: String,
-    src: Option<Box<dyn Error>>,
+    src: Option<Box<dyn Error + Send>>,
 }
 
 impl TinkError {
@@ -73,7 +73,7 @@ impl std::convert::From<String> for TinkError {
 /// ```
 pub fn wrap_err<T>(msg: &str, src: T) -> TinkError
 where
-    T: Error + 'static,
+    T: Error + Send + 'static,
 {
     TinkError {
         msg: msg.to_string(),


### PR DESCRIPTION
We have a use case where we're using `tink` in an async `tonic` service; with `TinkError` being `!Send`, we're unable to include it in our own error types and pass it around

Nothing in the `tink-rust` repo fails to build by adding this bound, but let me know if anything else requires testing