### PR TITLE
Demonstrate building for Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,7 @@ jobs:
           toolchain: 1.81.0
           override: true
           components: rustfmt
-      - uses: actions-rs/install@69ec87709ffb5b19a7b5ddbf610cb221498bb1eb # v0.1.2
-        with:
-          crate: cargo-tarpaulin
-          use-tool-cache: true
-          version: 0.32.3
+      - run: cargo install --locked --version 0.32.3 cargo-tarpaulin
       - run: cargo tarpaulin --verbose --ignore-tests --all-features --timeout=600 --out xml
       - name: Upload to codecov.io
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,17 @@ jobs:
       - run: rustc --version
       - run: cargo doc --no-deps --document-private-items --all-features
 
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions-rs/toolchain@63eb9591781c46a70274cb3ebdf190fce92702e8 # v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+          target: wasm32-unknown-unknown
+      - run: (cd examples/aead && cargo +1.81.0 build --target wasm32-unknown-unknown --release)
+
   udeps:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
 name = "example-aead"
 version = "0.3.0"
 dependencies = [
+ "getrandom",
  "hex",
  "tink-aead",
  "tink-core",
@@ -1005,8 +1006,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/examples/aead/Cargo.toml
+++ b/examples/aead/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# Force on the `js` feature of `getrandom` so a build of this example
+# for `wasm32-unknown-unknown` works.
+getrandom = { version = "^0.2.8", features = ["js"] }
 hex = "^0.4.3"
 tink-aead = "^0.3"
 tink-core = "^0.3"


### PR DESCRIPTION
Wasm itself does not include any source of randomness, so enable the `js` feature of the `getrandom` crate to allow use of WASI.